### PR TITLE
fix: base branch of pr creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,4 +69,5 @@ jobs:
 
             New digest: `${{ steps.build.outputs.digest }}`
           branch: update-docker-digest
+          base: main
           delete-branch: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the base branch to main for the auto-generated “update-docker-digest” PR in the release workflow, ensuring updates target the correct branch and merge cleanly.

<sup>Written for commit eaca776e11ecf902702d6c85b3b2398e01429e9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

