### PR TITLE
Jules/bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,11 +41,11 @@ jobs:
             type=sha,format=long
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           push: true
@@ -59,7 +59,7 @@ jobs:
           sed -i "s|ghcr.io/tinfoilsh/pri-build-action@sha256:[a-f0-9]*|ghcr.io/tinfoilsh/pri-build-action@${{ steps.build.outputs.digest }}|" action.yaml
 
       - name: Create PR for digest update
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 #v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update docker image digest to ${{ steps.build.outputs.digest }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,20 @@ FROM ubuntu:24.04
 
 WORKDIR /app
 COPY *.py /
-RUN mkdir -p /output
+RUN mkdir -p /output /cache
 
 RUN apt update && apt install -y curl python3 python3-venv
+
+# Install GitHub CLI for attestation verification
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && apt install -y gh
+
 RUN curl -L https://github.com/tinfoilsh/tdx-measure/releases/download/v0.0.6/tdx-measure -o tdx-measure
 RUN chmod +x tdx-measure
 
 RUN python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install --no-cache-dir sev-snp-measure pyyaml requests sigstore
+    /opt/venv/bin/pip install --no-cache-dir sev-snp-measure pyyaml requests
 
 ENTRYPOINT ["/opt/venv/bin/python", "/measure.py"]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: tinfoilsh/pri-build-action@main
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: tinfoilsh/pri-build-action@<hash>
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
           -v $(pwd)/output:/output \
           -v ${{ inputs.config-file }}:/config.yml \
           -e GH_TOKEN=${{ inputs.github-token }} \
-        ghcr.io/tinfoilsh/pri-build-action@sha256:bda76a3e76565c7f5b113f191f8ed423b1bcc06babbd517c9035506facff4876
+        ghcr.io/tinfoilsh/pri-build-action@sha256:42f0799da66519fcfb2dc4e5bf33fe3a3913f1207d8e5fdc127a1dc61316a446
 
     - name: Hash deployment manifest
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,18 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
+
+    - name: Ensure gh CLI supports attestation (>= 2.67.0)
+      run: |
+        GH_VERSION=$(gh --version | head -1 | awk '{print $3}')
+        MIN_VERSION="2.67.0"
+        echo "gh version: $GH_VERSION (minimum: $MIN_VERSION)"
+        
+        if [ "$(printf '%s\n' "$MIN_VERSION" "$GH_VERSION" | sort -V | head -1)" != "$MIN_VERSION" ]; then
+          echo "ERROR: gh CLI version $GH_VERSION is too old. Need >= $MIN_VERSION for attestation support."
+          exit 1
+        fi
 
     - name: Create deployment manifest
       shell: bash
@@ -37,7 +48,7 @@ runs:
         echo stdout=sha256:$(sudo sha256sum output/tinfoil-deployment.json | cut -d ' ' -f 1 | sudo tee output/tinfoil.hash) >> $GITHUB_OUTPUT
 
     - name: Attest
-      uses: actions/attest@v1
+      uses: actions/attest@7667f588f2f73a90cea6c7ac70e78266c4f76616 #v3.1.0
       id: attest
       with:
         subject-name: tinfoil-deployment.json
@@ -46,21 +57,27 @@ runs:
         predicate-path: output/tinfoil-deployment.json
 
     - name: Generate release notes
-      id: generate-release-notes
       shell: bash
       run: |
-        RELEASE_NOTES=$(cat output/release.md)
-        echo "release-notes<<EOF" >> "$GITHUB_OUTPUT"
-        echo "${RELEASE_NOTES}" >> "$GITHUB_OUTPUT"
-        echo "Digest: \`$(cat output/tinfoil.hash)\`" >> "$GITHUB_OUTPUT"
-        echo "Sigstore Link: https://search.sigstore.dev/?hash=$(cat output/tinfoil.hash)" >> "$GITHUB_OUTPUT"
-        echo "EOF" >> "$GITHUB_OUTPUT"
+        cat output/release.md > output/release-notes.md
+        echo "" >> output/release-notes.md
+        echo "Digest: \`$(cat output/tinfoil.hash)\`" >> output/release-notes.md
+        echo "Sigstore Link: https://search.sigstore.dev/?hash=$(cat output/tinfoil.hash)" >> output/release-notes.md
 
     - name: Create release
-      uses: softprops/action-gh-release@v2
-      with:
-        prerelease: ${{ inputs.prerelease == 'true' }}
-        files: |
-          output/tinfoil-deployment.json
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        PRERELEASE_FLAG=""
+        if [ "${{ inputs.prerelease }}" = "true" ]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        
+        gh release create "${{ github.ref_name }}" \
+          -R ${{ github.repository }} \
+          --title "${{ github.ref_name }}" \
+          --notes-file output/release-notes.md \
+          $PRERELEASE_FLAG \
+          output/tinfoil-deployment.json \
           output/tinfoil.hash
-        body: ${{ steps.generate-release-notes.outputs.release-notes }}

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
           -v $(pwd)/output:/output \
           -v ${{ inputs.config-file }}:/config.yml \
           -e GH_TOKEN=${{ inputs.github-token }} \
-        ghcr.io/tinfoilsh/pri-build-action@sha256:42f0799da66519fcfb2dc4e5bf33fe3a3913f1207d8e5fdc127a1dc61316a446
+        ghcr.io/tinfoilsh/pri-build-action@sha256:982805d8b74a22b5afbe394af2fb5b1f9c486776b23f3ca4766d9615aa24f7f9
 
     - name: Hash deployment manifest
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,7 @@ runs:
         docker run --rm \
           -v $(pwd)/output:/output \
           -v ${{ inputs.config-file }}:/config.yml \
+          -e GH_TOKEN=${{ inputs.github-token }} \
         ghcr.io/tinfoilsh/pri-build-action@sha256:fe1249ece772dfce71df53fc874699ad7a0769bc9c224fabc3cb113fb4bc062f
 
     - name: Hash deployment manifest

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,7 @@ runs:
           -v $(pwd)/output:/output \
           -v ${{ inputs.config-file }}:/config.yml \
           -e GH_TOKEN=${{ inputs.github-token }} \
-        ghcr.io/tinfoilsh/pri-build-action@sha256:fe1249ece772dfce71df53fc874699ad7a0769bc9c224fabc3cb113fb4bc062f
+        ghcr.io/tinfoilsh/pri-build-action@sha256:bda76a3e76565c7f5b113f191f8ed423b1bcc06babbd517c9035506facff4876
 
     - name: Hash deployment manifest
       shell: bash

--- a/measure.py
+++ b/measure.py
@@ -193,7 +193,7 @@ tdx_measurement = measure_intel(CPUS, MEMORY, kernel_file_tdx, initrd_file_tdx, 
 deployment_cfg = {
     "snp_measurement": snp_measurement,
     "tdx_measurement": tdx_measurement,
-    "cmdline": cmdline-tdx,
+    "cmdline": cmdline_tdx,
     "cmdline_snp": cmdline,
     "hashes": manifest,
     "config": base64.b64encode(open("/config.yml", "rb").read()).decode("utf-8"),

--- a/measure.py
+++ b/measure.py
@@ -12,7 +12,6 @@ from sigstore.errors import VerificationError
 RUNNER_ENVIRONMENT_OID = ObjectIdentifier("1.3.6.1.4.1.57264.1.11")
 OIDC_ISSUER = "https://token.actions.githubusercontent.com"
 
-
 def verify_attestation(attestations: list, repo: str) -> None:
     """Find and verify an attestation matching the given repo and policy."""
     verifier = Verifier.production()
@@ -57,15 +56,23 @@ from measure_intel import measure_intel
 from util import sha256sum, sha256sum_bytes, fetch
 
 CACHE_DIR = "/cache"
+TF_CORE_REPO = "tinfoilsh/tf-core"
 
 config = yaml.safe_load(open("/config.yml", "r"))
 
-CVM_VERSION = config["cvm-version"]
 CPUS = config["cpus"]
 MEMORY = config["memory"]
+PLATFORM = config["platform"]
+STAGE0_VERSION = config["stage0-version"]
 
+# Old cvmimage (tinfoilsh/cvmimage) for TDX
+CVM_VERSION = config["cvm-version"]
 CVMIMAGE_REPO = "tinfoilsh/cvmimage"
 
+# New cvmimage (tf-core) for AMD SNP
+CVMIMAGE_VERSION = config["cvmimage-version"]
+
+# === TDX: Old cvmimage from tinfoilsh/cvmimage ===
 manifest_url = f"https://github.com/{CVMIMAGE_REPO}/releases/download/v{CVM_VERSION}/tinfoil-inference-v{CVM_VERSION}-manifest.json"
 manifest_response = requests.get(manifest_url)
 manifest_response.raise_for_status()
@@ -78,43 +85,116 @@ attestation_response = requests.get(attestation_url)
 attestation_response.raise_for_status()
 
 verify_attestation(attestation_response.json()["attestations"], CVMIMAGE_REPO)
-print(f"Manifest attestation verified for {CVMIMAGE_REPO}")
+print(f"Manifest attestation verified for {CVMIMAGE_REPO} (TDX)")
 
-kernel_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR)
-initrd_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR)
+kernel_file_tdx = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR)
+initrd_file_tdx = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR)
 
-kernel_hash = sha256sum(kernel_file)
-initrd_hash = sha256sum(initrd_file)
+kernel_hash_tdx = sha256sum(kernel_file_tdx)
+initrd_hash_tdx = sha256sum(initrd_file_tdx)
 
-if kernel_hash != manifest["kernel"]:
-    raise ValueError(f"Kernel hash mismatch: expected {manifest['kernel']}, got {kernel_hash}")
-if initrd_hash != manifest["initrd"]:
-    raise ValueError(f"Initrd hash mismatch: expected {manifest['initrd']}, got {initrd_hash}")
+if kernel_hash_tdx != manifest["kernel"]:
+    raise ValueError(f"TDX kernel hash mismatch: expected {manifest['kernel']}, got {kernel_hash_tdx}")
+if initrd_hash_tdx != manifest["initrd"]:
+    raise ValueError(f"TDX initrd hash mismatch: expected {manifest['initrd']}, got {initrd_hash_tdx}")
 
-EDK2_REPO = "tinfoilsh/edk2"
-EDK2_VERSION = "v0.0.3"
+# === AMD SNP: New cvmimage from tf-core ===
+manifest_snp_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{CVMIMAGE_VERSION}/manifest.json"
+manifest_snp_response = requests.get(manifest_snp_url)
+manifest_snp_response.raise_for_status()
+manifest_snp_bytes = manifest_snp_response.content
+manifest_snp = json.loads(manifest_snp_bytes)
 
-amd_ovmf = fetch(f"https://github.com/{EDK2_REPO}/releases/download/{EDK2_VERSION}/OVMF.fd", CACHE_DIR)
-ovmf_digest = sha256sum(amd_ovmf)
+manifest_snp_digest = sha256sum_bytes(manifest_snp_bytes)
+attestation_snp_url = f"https://api.github.com/repos/{TF_CORE_REPO}/attestations/sha256:{manifest_snp_digest}"
+attestation_snp_response = requests.get(attestation_snp_url)
+attestation_snp_response.raise_for_status()
 
-ovmf_attestation_url = f"https://api.github.com/repos/{EDK2_REPO}/attestations/sha256:{ovmf_digest}"
-ovmf_attestation_response = requests.get(ovmf_attestation_url)
-ovmf_attestation_response.raise_for_status()
+verify_attestation(attestation_snp_response.json()["attestations"], TF_CORE_REPO)
+print(f"Manifest attestation verified for {TF_CORE_REPO} (AMD SNP)")
 
-verify_attestation(ovmf_attestation_response.json()["attestations"], EDK2_REPO)
-print(f"OVMF attestation verified for {EDK2_REPO}")
+# Download kernel/initrd from R2 (uploaded by system-cvmimage workflow)
+kernel_file_snp = fetch("https://images.tinfoil.sh/cvm/tinfoilcvm.vmlinuz", CACHE_DIR)
+initrd_file_snp = fetch("https://images.tinfoil.sh/cvm/tinfoilcvm.initrd", CACHE_DIR)
 
-cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
+kernel_hash_snp = sha256sum(kernel_file_snp)
+initrd_hash_snp = sha256sum(initrd_file_snp)
+
+if kernel_hash_snp != manifest_snp["vmlinuz_sha256"]:
+    raise ValueError(f"SNP kernel hash mismatch: expected {manifest_snp['vmlinuz_sha256']}, got {kernel_hash_snp}")
+if initrd_hash_snp != manifest_snp["initrd_sha256"]:
+    raise ValueError(f"SNP initrd hash mismatch: expected {manifest_snp['initrd_sha256']}, got {initrd_hash_snp}")
+
+# Download stage0 from tf-core (for AMD SNP)
+stage0_file = fetch(f"https://github.com/{TF_CORE_REPO}/releases/download/{STAGE0_VERSION}/stage0_bin", CACHE_DIR)
+stage0_digest = sha256sum(stage0_file)
+
+stage0_attestation_url = f"https://api.github.com/repos/{TF_CORE_REPO}/attestations/sha256:{stage0_digest}"
+stage0_attestation_response = requests.get(stage0_attestation_url)
+stage0_attestation_response.raise_for_status()
+
+verify_attestation(stage0_attestation_response.json()["attestations"], TF_CORE_REPO)
+print(f"Stage0 attestation verified for {TF_CORE_REPO}")
+
+# Get ACPI hash from platform-measurements release
+# Find latest plt-msr-v* release
+releases_url = f"https://api.github.com/repos/{TF_CORE_REPO}/releases"
+releases_response = requests.get(releases_url)
+releases_response.raise_for_status()
+releases = releases_response.json()
+
+plt_msr_release = None
+for release in releases:
+    if release["tag_name"].startswith("plt-msr-v"):
+        plt_msr_release = release
+        break
+
+if not plt_msr_release:
+    raise ValueError("No platform measurements release (plt-msr-v*) found in tf-core")
+
+print(f"Using platform measurements release: {plt_msr_release['tag_name']}")
+
+# Download platform-measurements.json from the release
+measurements_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{plt_msr_release['tag_name']}/platform-measurements.json"
+measurements_response = requests.get(measurements_url)
+measurements_response.raise_for_status()
+measurements_bytes = measurements_response.content
+platform_measurements = json.loads(measurements_bytes)
+
+# Verify attestation for platform-measurements.json
+measurements_digest = sha256sum_bytes(measurements_bytes)
+measurements_attestation_url = f"https://api.github.com/repos/{TF_CORE_REPO}/attestations/sha256:{measurements_digest}"
+measurements_attestation_response = requests.get(measurements_attestation_url)
+measurements_attestation_response.raise_for_status()
+
+verify_attestation(measurements_attestation_response.json()["attestations"], TF_CORE_REPO)
+print(f"Platform measurements attestation verified for {TF_CORE_REPO}")
+
+if PLATFORM not in platform_measurements:
+    raise ValueError(f"Platform '{PLATFORM}' not found in platform-measurements.json. Available: {list(platform_measurements.keys())}")
+
+acpi_hash = platform_measurements[PLATFORM]["acpi"]
+print(f"ACPI hash for {PLATFORM}: {acpi_hash}")
+
+# Cmdline for TDX (old cvmimage, without acpi_hash)
+cmdline_tdx = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
+
+# Cmdline for AMD SNP (new cvmimage, with acpi_hash)
+cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest_snp['disk_sha256']} tinfoil-config-hash={sha256sum('/config.yml')} acpi_hash={acpi_hash}"
 
 print("Measuring...")
 
-snp_measurement = measure_amd(CPUS, amd_ovmf, kernel_file, initrd_file, cmdline)
-tdx_measurement = measure_intel(CPUS, MEMORY, kernel_file, initrd_file, cmdline)
+# AMD SNP measurement (stage0-based, new cvmimage from tf-core)
+snp_measurement = measure_amd(CPUS, stage0_file, kernel_file_snp, initrd_file_snp, cmdline)
+
+# TDX measurement (old cvmimage from tinfoilsh/cvmimage)
+tdx_measurement = measure_intel(CPUS, MEMORY, kernel_file_tdx, initrd_file_tdx, cmdline_tdx)
 
 deployment_cfg = {
     "snp_measurement": snp_measurement,
     "tdx_measurement": tdx_measurement,
-    "cmdline": cmdline,
+    "cmdline": cmdline-tdx,
+    "cmdline_snp": cmdline,
     "hashes": manifest,
     "config": base64.b64encode(open("/config.yml", "rb").read()).decode("utf-8"),
 }

--- a/measure.py
+++ b/measure.py
@@ -85,13 +85,17 @@ PLATFORM = config["platform"]
 STAGE0_VERSION = config["stage0-version"]
 CVMIMAGE_VERSION = config["cvmimage-version"]
 
-new_manifest_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{CVMIMAGE_VERSION}/manifest.json"
+# Extract version numbers from tags (e.g., cvmimage-v0.0.5 -> v0.0.5)
+CVMIMAGE_VER = CVMIMAGE_VERSION.replace("cvmimage-", "")
+STAGE0_VER = STAGE0_VERSION.replace("stage0-", "")
+
+new_manifest_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{CVMIMAGE_VERSION}/manifest-{CVMIMAGE_VER}.json"
 new_manifest = fetch_verified_json_artifact(new_manifest_url, TF_CORE_REPO)
 
-# Download kernel/initrd from R2 (uploaded by system-cvmimage workflow)
-new_kernel_file = fetch_verified_artifact("https://images.tinfoil.sh/cvm/tinfoilcvm.vmlinuz", TF_CORE_REPO)
-new_initrd_file = fetch_verified_artifact("https://images.tinfoil.sh/cvm/tinfoilcvm.initrd", TF_CORE_REPO)
-new_stage0_file = fetch_verified_artifact(f"https://github.com/{TF_CORE_REPO}/releases/download/{STAGE0_VERSION}/stage0_bin", TF_CORE_REPO)
+# Download kernel/initrd/stage0 from R2
+new_kernel_file = fetch_verified_artifact(f"https://images.tinfoil.sh/cvm/tinfoilcvm-{CVMIMAGE_VER}.vmlinuz", TF_CORE_REPO)
+new_initrd_file = fetch_verified_artifact(f"https://images.tinfoil.sh/cvm/tinfoilcvm-{CVMIMAGE_VER}.initrd", TF_CORE_REPO)
+new_stage0_file = fetch_verified_artifact(f"https://images.tinfoil.sh/fw/stage0-{STAGE0_VER}.fd", TF_CORE_REPO)
 
 new_kernel_hash = sha256sum(new_kernel_file)
 new_initrd_hash = sha256sum(new_initrd_file)

--- a/measure.py
+++ b/measure.py
@@ -80,6 +80,7 @@ tdx_measurement = measure_intel(CPUS, MEMORY, old_kernel_file, old_initrd_file, 
 
 # === New release format used for AMD SNP ===
 TF_CORE_REPO = "tinfoilsh/tf-core"
+OAK_REPO = "tinfoilsh/oak"
 
 PLATFORM = config["platform"]
 STAGE0_VERSION = config["stage0-version"]
@@ -95,7 +96,7 @@ new_manifest = fetch_verified_json_artifact(new_manifest_url, TF_CORE_REPO)
 # Download kernel/initrd/stage0 from R2
 new_kernel_file = fetch_verified_artifact(f"https://images.tinfoil.sh/cvm/tinfoilcvm-{CVMIMAGE_VER}.vmlinuz", TF_CORE_REPO)
 new_initrd_file = fetch_verified_artifact(f"https://images.tinfoil.sh/cvm/tinfoilcvm-{CVMIMAGE_VER}.initrd", TF_CORE_REPO)
-new_stage0_file = fetch_verified_artifact(f"https://images.tinfoil.sh/fw/stage0-{STAGE0_VER}.fd", TF_CORE_REPO)
+new_stage0_file = fetch_verified_artifact(f"https://images.tinfoil.sh/fw/stage0-{STAGE0_VER}.fd", OAK_REPO)
 
 new_kernel_hash = sha256sum(new_kernel_file)
 new_initrd_hash = sha256sum(new_initrd_file)
@@ -146,7 +147,7 @@ md = f"""## Measurements
 | Component | Version |
 |-----------|---------|
 | CVM Image | [`{CVMIMAGE_VERSION}`](https://github.com/tinfoilsh/tf-core/releases/tag/{CVMIMAGE_VERSION}) |
-| Firmware (stage0) | [`{STAGE0_VERSION}`](https://github.com/tinfoilsh/tf-core/releases/tag/{STAGE0_VERSION}) |
+| Firmware (stage0) | [`{STAGE0_VERSION}`](https://github.com/tinfoilsh/oak/releases/tag/{STAGE0_VERSION}) |
 | Platform Measurements | [`{plt_msr_release}`](https://github.com/tinfoilsh/tf-core/releases/tag/{plt_msr_release}) |
 | Legacy CVM Image (TDX) | [`{CVM_VERSION}`](https://github.com/tinfoilsh/cvmimage/releases/tag/v{CVM_VERSION}) |
 

--- a/measure.py
+++ b/measure.py
@@ -4,7 +4,28 @@ import os
 import subprocess
 import requests
 import yaml
+from pathlib import Path
+from util import sha256sum, sha256sum_bytes, fetch
 
+from measure_amd import measure_amd
+from measure_intel import measure_intel
+
+def get_latest_release(repo: str, suffix: str):
+    releases_url = f"https://api.github.com/repos/{repo}/releases"
+    releases_response = requests.get(releases_url)
+    releases_response.raise_for_status()
+    releases = releases_response.json()
+
+    latest_release = None
+    for release in releases:
+        if release["tag_name"].startswith(suffix):
+            latest_release = release
+            break
+
+    if not latest_release:
+        raise ValueError(f"No {suffix} release found in {repo}")
+
+    return latest_release["tag_name"]
 
 def verify_attestation_gh(file_path: str, repo: str) -> None:
     """Verify attestation using GitHub CLI, ensuring it was built on GitHub-hosted runners."""
@@ -16,162 +37,116 @@ def verify_attestation_gh(file_path: str, repo: str) -> None:
     
     if result.returncode != 0:
         raise RuntimeError(f"Attestation verification failed for {file_path}: {result.stderr}")
-    
-    print(f"✓ Attestation verified: {file_path}")
-
-from measure_amd import measure_amd
-from measure_intel import measure_intel
-
-from util import sha256sum, sha256sum_bytes, fetch
 
 CACHE_DIR = "/cache"
-TF_CORE_REPO = "tinfoilsh/tf-core"
+
+def fetch_verified_artifact(url: str, repo: str) -> str:
+    file_path = fetch(url, CACHE_DIR)
+    verify_attestation_gh(file_path, repo)
+    artifact_name = artifact_name = Path(file_path).name
+    print(f"Attestation verified for {artifact_name} from {repo}")
+    return file_path
+
+def fetch_verified_json_artifact(url: str, repo: str) -> dict:
+   artifact_file = fetch_verified_artifact(url, repo)
+   return json.loads(open(artifact_file, "r").read()) 
 
 config = yaml.safe_load(open("/config.yml", "r"))
 
+# === Old release format used for TDX ===
+OLD_REPO = "tinfoilsh/cvmimage"
+
 CPUS = config["cpus"]
 MEMORY = config["memory"]
+CVM_VERSION = config["cvm-version"]
+
+old_manifest_url = f"https://github.com/{OLD_REPO}/releases/download/v{CVM_VERSION}/tinfoil-inference-v{CVM_VERSION}-manifest.json"
+old_manifest = fetch_verified_json_artifact(old_manifest_url, OLD_REPO)
+
+old_kernel_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR)
+old_initrd_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR)
+
+old_kernel_hash = sha256sum(old_kernel_file)
+old_initrd_hash = sha256sum(old_initrd_file)
+
+if old_kernel_hash != old_manifest["kernel"]:
+    raise ValueError(f"Old kernel hash mismatch...")
+if old_initrd_hash != old_manifest["initrd"]:
+    raise ValueError(f"Old initrd hash mismatch...")
+
+old_cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={old_manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
+
+tdx_measurement = measure_intel(CPUS, MEMORY, old_kernel_file, old_initrd_file, old_cmdline)
+
+# === New release format used for AMD SNP ===
+TF_CORE_REPO = "tinfoilsh/tf-core"
+
 PLATFORM = config["platform"]
 STAGE0_VERSION = config["stage0-version"]
-
-# Old cvmimage (tinfoilsh/cvmimage) for TDX
-CVM_VERSION = config["cvm-version"]
-CVMIMAGE_REPO = "tinfoilsh/cvmimage"
-
-# New cvmimage (tf-core) for AMD SNP
 CVMIMAGE_VERSION = config["cvmimage-version"]
 
-# === TDX: Old cvmimage from tinfoilsh/cvmimage ===
-manifest_url = f"https://github.com/{CVMIMAGE_REPO}/releases/download/v{CVM_VERSION}/tinfoil-inference-v{CVM_VERSION}-manifest.json"
-manifest_response = requests.get(manifest_url)
-manifest_response.raise_for_status()
-manifest_bytes = manifest_response.content
-manifest = json.loads(manifest_bytes)
+new_manifest_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{CVMIMAGE_VERSION}/manifest.json"
+new_manifest = fetch_verified_json_artifact(new_manifest_url, TF_CORE_REPO)
 
-# Save manifest to verify attestation
-manifest_file_tdx = f"{CACHE_DIR}/manifest-tdx.json"
-os.makedirs(CACHE_DIR, exist_ok=True)
-with open(manifest_file_tdx, "wb") as f:
-    f.write(manifest_bytes)
-
-verify_attestation_gh(manifest_file_tdx, CVMIMAGE_REPO)
-print(f"Manifest attestation verified for {CVMIMAGE_REPO} (TDX)")
-
-kernel_file_tdx = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR)
-initrd_file_tdx = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR)
-
-kernel_hash_tdx = sha256sum(kernel_file_tdx)
-initrd_hash_tdx = sha256sum(initrd_file_tdx)
-
-if kernel_hash_tdx != manifest["kernel"]:
-    raise ValueError(f"TDX kernel hash mismatch: expected {manifest['kernel']}, got {kernel_hash_tdx}")
-if initrd_hash_tdx != manifest["initrd"]:
-    raise ValueError(f"TDX initrd hash mismatch: expected {manifest['initrd']}, got {initrd_hash_tdx}")
-
-# === AMD SNP: New cvmimage from tf-core ===
 # Download kernel/initrd from R2 (uploaded by system-cvmimage workflow)
-kernel_file_snp = fetch("https://images.tinfoil.sh/cvm/tinfoilcvm.vmlinuz", CACHE_DIR)
-initrd_file_snp = fetch("https://images.tinfoil.sh/cvm/tinfoilcvm.initrd", CACHE_DIR)
+new_kernel_file = fetch_verified_artifact("https://images.tinfoil.sh/cvm/tinfoilcvm.vmlinuz", TF_CORE_REPO)
+new_initrd_file = fetch_verified_artifact("https://images.tinfoil.sh/cvm/tinfoilcvm.initrd", TF_CORE_REPO)
+new_stage0_file = fetch_verified_artifact(f"https://github.com/{TF_CORE_REPO}/releases/download/{STAGE0_VERSION}/stage0_bin", TF_CORE_REPO)
 
-kernel_hash_snp = sha256sum(kernel_file_snp)
-initrd_hash_snp = sha256sum(initrd_file_snp)
+new_kernel_hash = sha256sum(new_kernel_file)
+new_initrd_hash = sha256sum(new_initrd_file)
 
-# Verify attestations for the actual artifacts directly using gh CLI
-verify_attestation_gh(kernel_file_snp, TF_CORE_REPO)
-print(f"Kernel attestation verified for {TF_CORE_REPO} (AMD SNP)")
+if new_kernel_hash != new_manifest["kernel"]:
+    raise ValueError(f"New kernel hash mismatch... {new_kernel_hash} != {new_manifest['kernel']}")
+if new_initrd_hash != new_manifest["initrd"]:
+    raise ValueError(f"New initrd hash mismatch... {new_initrd_hash} != {new_manifest['initrd']}")
 
-verify_attestation_gh(initrd_file_snp, TF_CORE_REPO)
-print(f"Initrd attestation verified for {TF_CORE_REPO} (AMD SNP)")
-
-# Get manifest for root (roothash)
-manifest_snp_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{CVMIMAGE_VERSION}/manifest.json"
-manifest_snp_response = requests.get(manifest_snp_url)
-manifest_snp_response.raise_for_status()
-manifest_snp_bytes = manifest_snp_response.content 
-manifest_snp = json.loads(manifest_snp_bytes)
-
-# Save manifest to verify attestation
-manifest_file_snp = f"{CACHE_DIR}/manifest-snp.json"
-with open(manifest_file_snp, "wb") as f:
-    f.write(manifest_snp_bytes)
-
-verify_attestation_gh(manifest_file_snp, TF_CORE_REPO)
-print(f"Manifest attestation verified for {TF_CORE_REPO} (AMD SNP)")
-
-# Download stage0 from tf-core (for AMD SNP)
-stage0_file = fetch(f"https://github.com/{TF_CORE_REPO}/releases/download/{STAGE0_VERSION}/stage0_bin", CACHE_DIR)
-stage0_digest = sha256sum(stage0_file)
-
-verify_attestation_gh(stage0_file, TF_CORE_REPO)
-print(f"Stage0 attestation verified for {TF_CORE_REPO}")
-
-# Get ACPI hash from platform-measurements release
-# Find latest plt-msr-v* release
-releases_url = f"https://api.github.com/repos/{TF_CORE_REPO}/releases"
-releases_response = requests.get(releases_url)
-releases_response.raise_for_status()
-releases = releases_response.json()
-
-plt_msr_release = None
-for release in releases:
-    if release["tag_name"].startswith("plt-msr-v"):
-        plt_msr_release = release
-        break
-
-if not plt_msr_release:
-    raise ValueError("No platform measurements release (plt-msr-v*) found in tf-core")
-
-print(f"Using platform measurements release: {plt_msr_release['tag_name']}")
+plt_msr_release = get_latest_release(TF_CORE_REPO, "plt-msr-v")
 
 # Download platform-measurements.json from the release
-measurements_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{plt_msr_release['tag_name']}/platform-measurements.json"
-measurements_response = requests.get(measurements_url)
-measurements_response.raise_for_status()
-measurements_bytes = measurements_response.content
-platform_measurements = json.loads(measurements_bytes)
+plt_msr_measurements_url = f"https://github.com/{TF_CORE_REPO}/releases/download/{plt_msr_release}/platform-measurements.json"
+plt_msr_measurements = fetch_verified_json_artifact(plt_msr_measurements_url, TF_CORE_REPO)
 
-# Verify attestation for platform-measurements.json
-measurements_file = f"{CACHE_DIR}/platform-measurements.json"
-with open(measurements_file, "wb") as f:
-    f.write(measurements_bytes)
-
-verify_attestation_gh(measurements_file, TF_CORE_REPO)
-print(f"Platform measurements attestation verified for {TF_CORE_REPO}")
-
-if PLATFORM not in platform_measurements:
-    raise ValueError(f"Platform '{PLATFORM}' not found in platform-measurements.json. Available: {list(platform_measurements.keys())}")
-
-acpi_hash = platform_measurements[PLATFORM]["acpi"]
-print(f"ACPI hash for {PLATFORM}: {acpi_hash}")
-
-# Cmdline for TDX (old cvmimage, without acpi_hash)
-cmdline_tdx = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
+if PLATFORM not in plt_msr_measurements:
+    raise ValueError(f"Platform '{PLATFORM}' not found in platform-measurements.json. Available: {list(plt_msr_measurements.keys())}")
 
 # Cmdline for AMD SNP (new cvmimage, with acpi_hash)
-cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest_snp['root']} tinfoil-config-hash={sha256sum('/config.yml')} acpi_hash={acpi_hash}"
-
-print("Measuring...")
+acpi_hash = plt_msr_measurements[PLATFORM]["acpi"]
+new_cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={new_manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')} acpi_hash={acpi_hash}"
 
 # AMD SNP measurement (stage0-based, new cvmimage from tf-core)
-snp_measurement = measure_amd(CPUS, stage0_file, kernel_file_snp, initrd_file_snp, cmdline)
+snp_measurement = measure_amd(CPUS, new_stage0_file, new_kernel_file, new_initrd_file, new_cmdline)
 
-# TDX measurement (old cvmimage from tinfoilsh/cvmimage)
-tdx_measurement = measure_intel(CPUS, MEMORY, kernel_file_tdx, initrd_file_tdx, cmdline_tdx)
-
+# === Finalize Release ===
 deployment_cfg = {
     "snp_measurement": snp_measurement,
     "tdx_measurement": tdx_measurement,
-    "cmdline": cmdline_tdx,
-    "cmdline_snp": cmdline,
-    "hashes": manifest,
+    "cmdline": old_cmdline,
+    "cmdline_stage0": new_cmdline,
+    "hashes": old_manifest,
+    "hashes_stage0": new_manifest,
     "config": base64.b64encode(open("/config.yml", "rb").read()).decode("utf-8"),
 }
 
 print(deployment_cfg)
 
-md = f"""SEV-SNP Measurement: `{deployment_cfg['snp_measurement']}`
-TDX Measurement: `{deployment_cfg['tdx_measurement']}`
-Inference Image Version: [`{CVM_VERSION}`](https://github.com/tinfoilsh/cvmimage/releases/tag/v{CVM_VERSION})
+md = f"""## Measurements
+
+| Platform | Measurement |
+|----------|-------------|
+| AMD SEV-SNP | `{snp_measurement}` |
+| Intel TDX | `{tdx_measurement}` |
+
+## Build Artifacts
+
+| Component | Version |
+|-----------|---------|
+| CVM Image | [`{CVMIMAGE_VERSION}`](https://github.com/tinfoilsh/tf-core/releases/tag/{CVMIMAGE_VERSION}) |
+| Firmware (stage0) | [`{STAGE0_VERSION}`](https://github.com/tinfoilsh/tf-core/releases/tag/{STAGE0_VERSION}) |
+| Platform Measurements | [`{plt_msr_release}`](https://github.com/tinfoilsh/tf-core/releases/tag/{plt_msr_release}) |
+| Legacy CVM Image (TDX) | [`{CVM_VERSION}`](https://github.com/tinfoilsh/cvmimage/releases/tag/v{CVM_VERSION}) |
+
+All artifacts verified via GitHub attestation.
 """
 
 with open("/output/release.md", "w") as f:

--- a/measure_amd.py
+++ b/measure_amd.py
@@ -2,10 +2,11 @@ from sevsnpmeasure import guest
 from sevsnpmeasure.vcpu_types import CPU_SIGS
 from sevsnpmeasure.vmm_types import VMMType
 
-def measure_amd(num_cpus, ovmf_file, kernel_file, initrd_file, cmdline):
+def measure_amd(num_cpus, firmware_file, kernel_file, initrd_file, cmdline):
+    """Compute AMD SEV-SNP launch digest. firmware_file can be OVMF or stage0."""
     ld = guest.snp_calc_launch_digest(
         num_cpus, CPU_SIGS["EPYC-v4"],
-        ovmf_file, kernel_file, initrd_file, cmdline,
+        firmware_file, kernel_file, initrd_file, cmdline,
         0x1, "", VMMType.QEMU, dump_vmsa=False,
     )
     return ld.hex()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds stage0-based AMD SEV-SNP measurement and switches to tf-core manifests, with strict artifact verification using GitHub attestations. Pins GitHub Actions to commit SHAs and creates releases via gh to strengthen supply-chain integrity.

- **New Features**
  - Measure AMD SEV-SNP using stage0 firmware, new tf-core cvmimage, and acpi_hash from platform-measurements; keep Intel TDX measurement via legacy cvmimage.
  - Verify all artifacts (manifests, kernel, initrd, firmware) with gh attestation and deny self-hosted runners.
  - Generate release notes and publish releases using gh, attaching deployment JSON and hash.

- **Dependencies**
  - Install GitHub CLI in the container; require gh >= 2.67.0 in the action.
  - Pin all actions to commit SHAs in release workflow and composite action.
  - Remove Python sigstore dependency; add /cache and pass GH_TOKEN to docker.
  - Update README to use pinned checkout and action digest placeholder.

<sup>Written for commit 165d859793af8b88b0a3dd519406018a4422142e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

