### PR TITLE
nit: rename repo measure-image-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           BRANCH="digest-update/${VERSION}"
 
-          sed -i "s|ghcr.io/tinfoilsh/pri-build-action@sha256:[a-f0-9]*|ghcr.io/tinfoilsh/pri-build-action@${DIGEST}|" action.yaml
+          sed -i "s|ghcr.io/tinfoilsh/measure-image-action@sha256:[a-f0-9]*|ghcr.io/tinfoilsh/measure-image-action@${DIGEST}|" action.yaml
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             exit 1
           fi
 
-          ACTUAL_DIGEST=$(grep -oP 'pri-build-action@\Ksha256:[a-f0-9]+' action.yaml)
+          ACTUAL_DIGEST=$(grep -oP 'measure-image-action@\Ksha256:[a-f0-9]+' action.yaml)
           if [ "${ACTUAL_DIGEST}" != "${DIGEST}" ]; then
             echo "::error::Digest mismatch! action.yaml has ${ACTUAL_DIGEST} but expected ${DIGEST}. Was the digest update PR merged?"
             exit 1
@@ -70,5 +70,5 @@ jobs:
 
           **Usage (pin by commit SHA):**
           \`\`\`yaml
-          - uses: tinfoilsh/pri-build-action@${COMMIT_SHA}  # ${VERSION}
+          - uses: tinfoilsh/measure-image-action@${COMMIT_SHA}  # ${VERSION}
           \`\`\`"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: tinfoilsh/pri-build-action@<COMMIT_SHA>  # pin to latest release tag commit
+      - uses: tinfoilsh/measure-image-action@<COMMIT_SHA>  # pin to latest release tag commit
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,5 +45,5 @@ This will:
 
 Downstream users can then pin to the new version:
 ```yaml
-- uses: tinfoilsh/pri-build-action@v0.0.13
+- uses: tinfoilsh/measure-image-action@v0.0.13
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
           -v "$(pwd)/output":/output \
           -v "${{ inputs.config-file }}":/config.yml:ro \
           -e GH_TOKEN=${{ inputs.github-token }} \
-        ghcr.io/tinfoilsh/pri-build-action@sha256:051a24ae1aa64e7f442106291bf429f823235204fd489678ebb29f356a5beb49
+        ghcr.io/tinfoilsh/measure-image-action@sha256:051a24ae1aa64e7f442106291bf429f823235204fd489678ebb29f356a5beb49
 
     - name: Fix output permissions
       shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the action and GHCR image to `tinfoilsh/measure-image-action` and updated all references.
This updates the `action.yaml` run image, the `build.yml` digest sed, `release.yml` digest validation and usage snippet, and README examples.

<sup>Written for commit b2107427ff79ffc9d253ba28043d6bdad0f3b5c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

