### PR TITLE
nit: simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,3 @@ Push a `build-v*` tag to trigger the automated pipeline:
 git tag build-v0.0.13
 git push origin build-v0.0.13
 ```
-
-This will:
-1. Build and push the container image to ghcr.io
-2. Update `action.yaml` with the new container digest
-3. Commit the digest update to `main`
-4. Create a `v0.0.13` release tag on the commit with the correct digest
-5. Create a GitHub Release
-
-Downstream users can then pin to the new version:
-```yaml
-- uses: tinfoilsh/measure-image-action@v0.0.13
-```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the README by keeping only the tag-and-push example for triggering the build, and removing the step-by-step release notes and version pinning snippet. This makes the release instructions shorter and clearer.

<sup>Written for commit b347bea94410645bbfe945ac81d8bdb7f7ca5355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

