### PR TITLE
Fix/diverse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -72,3 +73,40 @@ jobs:
           \`\`\`yaml
           - uses: tinfoilsh/measure-image-action@${COMMIT_SHA}  # ${VERSION}
           \`\`\`"
+
+      - name: Update README with pinned SHA
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+          BRANCH="readme-update/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "${BRANCH}"
+
+          sed -i -E "s|measure-image-action@[a-f0-9]{40}[^\"]*|measure-image-action@${COMMIT_SHA}  # ${VERSION}|g" README.md
+
+          if git diff --quiet README.md; then
+            echo "README already up to date"
+            exit 0
+          fi
+
+          git add README.md
+          git commit -m "chore: update action in README to ${VERSION} (${COMMIT_SHA})"
+          git push -f origin "${BRANCH}"
+
+          PR_URL=$(gh pr create \
+            --title "chore: update action in README to ${VERSION}" \
+            --body "Automated update of the pinned commit SHA in README.md after release ${VERSION}." \
+            --base main \
+            --head "${BRANCH}")
+
+          echo "PR created: ${PR_URL}"
+
+          gh pr merge "${PR_URL}" --rebase || \
+            gh pr merge "${PR_URL}" --auto --rebase || \
+            echo "::warning::Could not auto-merge README update PR. Merge it manually: ${PR_URL}"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: tinfoilsh/measure-image-action@<COMMIT_SHA>  # pin to latest release tag commit
+      - uses: tinfoilsh/measure-image-action@da7ccc11dcbbce00e602432e9ac01bcf9d5602ee   # v0.6.3
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -10,8 +10,8 @@ inputs:
   github-token:
     description: "GitHub token"
     required: true
-  prerelease:
-    description: "Whether to mark the GitHub release as a prerelease"
+  mark-as-latest:
+    description: "Mark the GitHub release as the latest (default: not marked as latest)"
     required: false
     default: "false"
 
@@ -79,15 +79,15 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        PRERELEASE_FLAG=""
-        if [ "${{ inputs.prerelease }}" = "true" ]; then
-          PRERELEASE_FLAG="--prerelease"
+        LATEST_FLAG="--latest=false"
+        if [ "${{ inputs.mark-as-latest }}" = "true" ]; then
+          LATEST_FLAG="--latest=true"
         fi
         
         gh release create "${{ github.ref_name }}" \
           -R ${{ github.repository }} \
           --title "${{ github.ref_name }}" \
           --notes-file output/release-notes.md \
-          $PRERELEASE_FLAG \
+          $LATEST_FLAG \
           output/tinfoil-deployment.json \
           output/tinfoil.hash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates pinning the README to the release commit SHA and switches release publishing to opt-in “Latest” tagging. Updated the example to v0.6.3.

- **New Features**
  - After each release, auto-open and attempt to auto-merge a PR that updates `README.md` to pin `tinfoilsh/measure-image-action` to the release commit SHA.

- **Migration**
  - If you use this action, replace the `prerelease` input with `mark-as-latest` (default false). Set it to true to mark the GitHub release as “Latest”.

<sup>Written for commit 4b5ac6ed43374a1c809cd355c3897c7c35039cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

