### PR TITLE
fix: delete automated branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,10 +107,10 @@ jobs:
           echo "PR created: ${PR_URL}"
 
           # Try direct merge first, then fall back to auto-merge
-          if gh pr merge "${PR_URL}" --rebase; then
+          if gh pr merge "${PR_URL}" --rebase --delete-branch; then
             echo "PR merged directly"
             echo "merged=true" >> $GITHUB_OUTPUT
-          elif gh pr merge "${PR_URL}" --auto --rebase; then
+          elif gh pr merge "${PR_URL}" --auto --rebase --delete-branch; then
             echo "Auto-merge enabled, waiting for merge..."
             for i in $(seq 1 30); do
               STATE=$(gh pr view "${PR_URL}" --json state -q .state)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,6 @@ jobs:
 
           echo "PR created: ${PR_URL}"
 
-          gh pr merge "${PR_URL}" --rebase || \
-            gh pr merge "${PR_URL}" --auto --rebase || \
+          gh pr merge "${PR_URL}" --rebase --delete-branch || \
+            gh pr merge "${PR_URL}" --auto --rebase --delete-branch || \
             echo "::warning::Could not auto-merge README update PR. Merge it manually: ${PR_URL}"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-delete branches created by our workflows after their PRs merge to keep the repo clean. Adds `--delete-branch` to `gh pr merge` for both direct and `--auto` merges in `.github/workflows/build.yml` and `.github/workflows/release.yml`.

<sup>Written for commit ff6f026f143dff5ff597ea3add9677b20fd1dfce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

