### PR TITLE
fix: build errors

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,6 +42,7 @@ runs:
           --read-only \
           --tmpfs /tmp \
           --tmpfs /cache \
+          --tmpfs /root/.cache \
           -v "$(pwd)/output":/output \
           -v "${{ inputs.config-file }}":/config.yml:ro \
           -e GH_TOKEN=${{ inputs.github-token }} \

--- a/measure.py
+++ b/measure.py
@@ -63,7 +63,7 @@ if initrd_hash != manifest["initrd"]:
 EDK2_REPO = "tinfoilsh/edk2"
 EDK2_VERSION = "v0.0.3"
 
-amd_ovmf = fetch_verified_artifact(f"https://github.com/{EDK2_REPO}/releases/download/{EDK2_VERSION}/OVMF.fd", EDK2_REPO)
+amd_ovmf = fetch(f"https://github.com/{EDK2_REPO}/releases/download/{EDK2_VERSION}/OVMF.fd", CACHE_DIR)
 
 cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CI build failures by making the Docker container cache writable and updating the OVMF download to use the cache-aware fetch path.

- **Bug Fixes**
  - Add `--tmpfs /root/.cache` in `action.yaml` to avoid write errors with a read-only root.
  - Switch to `fetch(..., CACHE_DIR)` for `OVMF.fd` in `measure.py` to match the existing API and prevent signature errors.

<sup>Written for commit 7cfb9bc779bdb9988ecb7e20bdefe0de4c3c79bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

