### PR TITLE
feat: allow passing in the release reference as an argument

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -83,15 +83,18 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        RELEASE_REF: ${{ inputs.release-ref || github.ref_name }}
+        MARK_AS_LATEST: ${{ inputs.mark-as-latest }}
+        REPO: ${{ github.repository }}
       run: |
         LATEST_FLAG="--latest=false"
-        if [ "${{ inputs.mark-as-latest }}" = "true" ]; then
+        if [ "$MARK_AS_LATEST" = "true" ]; then
           LATEST_FLAG="--latest=true"
         fi
-        
-        gh release create "${{ inputs.release-ref || github.ref_name }}" \
-          -R ${{ github.repository }} \
-          --title "${{ inputs.release-ref || github.ref_name }}" \
+
+        gh release create "$RELEASE_REF" \
+          -R "$REPO" \
+          --title "$RELEASE_REF" \
           --notes-file output/release-notes.md \
           $LATEST_FLAG \
           output/tinfoil-deployment.json \

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     description: "Mark the GitHub release as the latest (default: not marked as latest)"
     required: false
     default: "false"
+  release-ref:
+    description: "Git tag used as the release name and title (default: github.ref_name)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -85,9 +89,9 @@ runs:
           LATEST_FLAG="--latest=true"
         fi
         
-        gh release create "${{ github.ref_name }}" \
+        gh release create "${{ inputs.release-ref || github.ref_name }}" \
           -R ${{ github.repository }} \
-          --title "${{ github.ref_name }}" \
+          --title "${{ inputs.release-ref || github.ref_name }}" \
           --notes-file output/release-notes.md \
           $LATEST_FLAG \
           output/tinfoil-deployment.json \


### PR DESCRIPTION
This is used when the release should be made off a ref other than the reference of the workflow that triggered the action (e.g. `github.ref_name`). This is useful when the triggering workflow creates a new tag for the release and wants to run this action on that new tag rather than the tag the workflow was originally started on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `release-ref` input to choose the tag/ref used for the GitHub release. Defaults to `github.ref_name`; switches `gh` args to env vars with quoting to reduce injection risk.

- **New Features**
  - Add `release-ref` input; used for the release tag and title. Useful when the workflow creates a new tag to release.

- **Bug Fixes**
  - Pass args via env vars (`RELEASE_REF`, `MARK_AS_LATEST`, `REPO`) and quote in `gh` calls to avoid shell injection.

<sup>Written for commit 240f9d6113ed1ee7170ae95100fb854bccb30996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

