### PR TITLE
fix: verify tag before creating release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -93,6 +93,7 @@ runs:
         fi
 
         gh release create "$RELEASE_REF" \
+          --verify-tag \
           -R "$REPO" \
           --title "$RELEASE_REF" \
           --notes-file output/release-notes.md \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the release workflow verifies the tag before creating a GitHub release, preventing publishes from missing or moved tags. Adds `--verify-tag` to the `gh release create` command.

<sup>Written for commit ede8f8d0ffa2b396c72bd4c9a32bac0f52177750. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

