### PR TITLE
Add precondition check and perform checkout internally

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,9 @@ runs:
           exit 1
         fi
 
+    - name: Checkout
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
 

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,26 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Precondition checks
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        # Check that the action is being run from a tag
+        if [ "$REF_TYPE" != "tag" ]; then
+          echo "::error::measure-image-action must be run on a release tag, but this run is on $REF_TYPE '$REF_NAME'. Check how you are triggering this action."
+          exit 1
+        fi
+
+        # Check that the release does not already exist
+        if gh release view "$REF_NAME" >/dev/null 2>&1; then
+          echo "::error::Release $REF_NAME already exists — refusing to re-publish."
+          exit 1
+        fi
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add pre-run checks to ensure the action only runs from a tag and that the release doesn’t already exist, then perform repo checkout internally for simpler usage.

- New Features
  - Validate ref is a tag; fail early with a clear error if not.
  - Block if a release with the tag already exists to prevent re-publishing.
  - Use the provided `github-token` for `gh` release checks.
  - Perform internal checkout via `actions/checkout@v6.0.1` so consumers don’t need a separate checkout step.

<sup>Written for commit 89e387d94ff46904c8c71895d4a2cb483ca3fe7a. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/measure-image-action/pull/39?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

