### PR TITLE
chore: bump docker/setup-buildx-action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,7 +42,7 @@ runs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
     - name: Ensure gh CLI supports attestation (>= 2.67.0)
       shell: bash


### PR DESCRIPTION
Resolves the Github Actions Node20 deprecation warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `docker/setup-buildx-action` to v4.0.0 to resolve the GitHub Actions Node.js deprecation warning in our workflow. No other changes.

<sup>Written for commit 75e9f0a08f8125fe69769e95aee73be06c0a2de9. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/measure-image-action/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

