### PR TITLE
Allow hash pinning of cvm-version and ovmf-version

### DIFF
--- a/measure.py
+++ b/measure.py
@@ -1,25 +1,36 @@
 import base64
 import json
 import subprocess
-import yaml
 from pathlib import Path
+from typing import Optional, Tuple
+
+import yaml
 
 from measure_amd import measure_amd
 from measure_intel import measure_intel
-
-from util import sha256sum, fetch
+from util import fetch, sha256sum
 
 
 def verify_attestation_gh(file_path: str, repo: str) -> None:
     """Verify attestation using GitHub CLI, ensuring it was built on GitHub-hosted runners."""
     result = subprocess.run(
-        ["gh", "attestation", "verify", file_path, "-R", repo, "--deny-self-hosted-runners"],
+        [
+            "gh",
+            "attestation",
+            "verify",
+            file_path,
+            "-R",
+            repo,
+            "--deny-self-hosted-runners",
+        ],
         capture_output=True,
-        text=True
+        text=True,
     )
 
     if result.returncode != 0:
-        raise RuntimeError(f"Attestation verification failed for {file_path}: {result.stderr}")
+        raise RuntimeError(
+            f"Attestation verification failed for {file_path}: {result.stderr}"
+        )
 
 
 CACHE_DIR = "/cache"
@@ -33,37 +44,88 @@ def fetch_verified_artifact(url: str, repo: str) -> str:
     return file_path
 
 
-def fetch_verified_json_artifact(url: str, repo: str) -> dict:
-    artifact_file = fetch_verified_artifact(url, repo)
-    return json.loads(open(artifact_file, "r").read())
+def parse_pinned_name(value: str) -> Tuple[str, Optional[str]]:
+    """Parse a ``NAME`` or ``NAME@sha256:HEX`` reference.
+
+    Returns ``(name, digest)`` where ``digest`` is the lowercase hex SHA-256
+    (without the ``sha256:`` prefix) when one is present, else ``None``.
+
+    Used to parse the ``cvm-version`` and ``ovmf-version`` YAML config
+    fields, both of which mirror the OCI image digest-pinning convention
+    so a single string carries the human-readable version and an optional
+    integrity pin.
+    """
+    if "@" not in value:
+        return value, None
+    name, digest = value.split("@", 1)
+    if not digest.startswith("sha256:"):
+        raise ValueError(
+            f"unsupported digest algorithm in pinned reference: {value!r} "
+            f"(expected '<name>@sha256:<hex>')"
+        )
+    hex_digest = digest[len("sha256:") :]
+    if len(hex_digest) != 64 or not all(c in "0123456789abcdef" for c in hex_digest):
+        raise ValueError(
+            f"malformed sha256 digest in pinned reference: {value!r} "
+            f"(expected 64 lowercase hex chars)"
+        )
+    return name, hex_digest
+
+
+def verify_digest(file_path: str, expected_hex: str, label: str) -> None:
+    """Hash ``file_path`` and raise if it does not match ``expected_hex``."""
+    actual = sha256sum(file_path)
+    if actual != expected_hex:
+        raise ValueError(
+            f"{label} digest mismatch: expected sha256:{expected_hex}, "
+            f"got sha256:{actual}"
+        )
 
 
 config = yaml.safe_load(open("/config.yml", "r"))
 
-CVM_VERSION = config["cvm-version"]
+CVM_VERSION, CVM_MANIFEST_DIGEST = parse_pinned_name(str(config["cvm-version"]))
 CPUS = config["cpus"]
 MEMORY = config["memory"]
 
 CVMIMAGE_REPO = "tinfoilsh/cvmimage"
 
 manifest_url = f"https://github.com/{CVMIMAGE_REPO}/releases/download/v{CVM_VERSION}/tinfoil-inference-v{CVM_VERSION}-manifest.json"
-manifest = fetch_verified_json_artifact(manifest_url, CVMIMAGE_REPO)
+manifest_file = fetch_verified_artifact(manifest_url, CVMIMAGE_REPO)
 
-kernel_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR)
-initrd_file = fetch(f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR)
+if CVM_MANIFEST_DIGEST is not None:
+    verify_digest(manifest_file, CVM_MANIFEST_DIGEST, "cvm manifest")
+    print(f"Manifest digest matches pin: sha256:{CVM_MANIFEST_DIGEST}")
 
-kernel_hash = sha256sum(kernel_file)
-initrd_hash = sha256sum(initrd_file)
+manifest = json.loads(open(manifest_file, "r").read())
 
-if kernel_hash != manifest["kernel"]:
-    raise ValueError(f"Kernel hash mismatch: expected {manifest['kernel']}, got {kernel_hash}")
-if initrd_hash != manifest["initrd"]:
-    raise ValueError(f"Initrd hash mismatch: expected {manifest['initrd']}, got {initrd_hash}")
+kernel_file = fetch(
+    f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.vmlinuz", CACHE_DIR
+)
+initrd_file = fetch(
+    f"https://images.tinfoil.sh/cvm/tinfoil-inference-v{CVM_VERSION}.initrd", CACHE_DIR
+)
+
+verify_digest(kernel_file, manifest["kernel"], "kernel")
+verify_digest(initrd_file, manifest["initrd"], "initrd")
 
 EDK2_REPO = "tinfoilsh/edk2"
-EDK2_VERSION = "v0.0.3"
+DEFAULT_EDK2_VERSION = "v0.0.3"
 
-amd_ovmf = fetch(f"https://github.com/{EDK2_REPO}/releases/download/{EDK2_VERSION}/OVMF.fd", CACHE_DIR)
+ovmf_version_raw = config.get("ovmf-version")
+if ovmf_version_raw is not None:
+    EDK2_VERSION, OVMF_DIGEST = parse_pinned_name(str(ovmf_version_raw))
+else:
+    EDK2_VERSION = DEFAULT_EDK2_VERSION
+    OVMF_DIGEST = None
+
+amd_ovmf = fetch(
+    f"https://github.com/{EDK2_REPO}/releases/download/{EDK2_VERSION}/OVMF.fd",
+    CACHE_DIR,
+)
+if OVMF_DIGEST is not None:
+    verify_digest(amd_ovmf, OVMF_DIGEST, "ovmf")
+    print(f"OVMF digest matches pin: sha256:{OVMF_DIGEST}")
 
 cmdline = f"readonly=on pci=realloc,nocrs modprobe.blacklist=nouveau nouveau.modeset=0 root=/dev/mapper/root roothash={manifest['root']} tinfoil-config-hash={sha256sum('/config.yml')}"
 
@@ -82,8 +144,8 @@ deployment_cfg = {
 
 print(deployment_cfg)
 
-md = f"""SEV-SNP Measurement: `{deployment_cfg['snp_measurement']}`
-TDX Measurement: `{deployment_cfg['tdx_measurement']}`
+md = f"""SEV-SNP Measurement: `{deployment_cfg["snp_measurement"]}`
+TDX Measurement: `{deployment_cfg["tdx_measurement"]}`
 Inference Image Version: [`{CVM_VERSION}`](https://github.com/tinfoilsh/cvmimage/releases/tag/v{CVM_VERSION})
 """
 

--- a/measure.py
+++ b/measure.py
@@ -114,6 +114,7 @@ DEFAULT_EDK2_VERSION = "v0.0.3"
 
 ovmf_version_raw = config.get("ovmf-version")
 if ovmf_version_raw is not None:
+    print("::warning::The `ovmf-version` field is not currently supported by Tinfoil infrastructure and may cause an attestation error during deployment.")
     EDK2_VERSION, OVMF_DIGEST = parse_pinned_name(str(ovmf_version_raw))
 else:
     EDK2_VERSION = DEFAULT_EDK2_VERSION


### PR DESCRIPTION
- Adds support for `@sha256:{hash}` to `cvm-version`, where hash is the manifest
- Adds optional `ovmf-version` field in the same format.

Previously, the computed measurement used whatever values were returned from the fetch. This change enforces that the returned value is, in fact, the specified and presumably reviewed version.

The closed source deployment code won't use the ovmf version specified here (it presumably also hard codes v0.0.3). It may be better for it to detect such a mismatch and fail the deploy; as it stands, specifying a non-supported version would first fail during measurement validation.